### PR TITLE
Minor adjustments for Unity PSM

### DIFF
--- a/include/psp2/ctrl.h
+++ b/include/psp2/ctrl.h
@@ -32,8 +32,8 @@ enum {
 	PSP2_CTRL_RIGHT		= 0x000020,	//!< Right D-Pad button.
 	PSP2_CTRL_DOWN		= 0x000040,	//!< Down D-Pad button.
 	PSP2_CTRL_LEFT		= 0x000080,	//!< Left D-Pad button.
-	PSP2_CTRL_LTRIGGER	= 0x000100,	//!< Left trigger.
-	PSP2_CTRL_RTRIGGER	= 0x000200,	//!< Right trigger.
+	PSP2_CTRL_LTRIGGER	= 0x000500,	//!< Left trigger.
+	PSP2_CTRL_RTRIGGER	= 0x000A00,	//!< Right trigger.
 	PSP2_CTRL_TRIANGLE	= 0x001000,	//!< Triangle button.
 	PSP2_CTRL_CIRCLE	= 0x002000,	//!< Circle button.
 	PSP2_CTRL_CROSS		= 0x004000,	//!< Cross button.

--- a/include/psp2/touch.h
+++ b/include/psp2/touch.h
@@ -20,7 +20,7 @@ extern "C" {
 
 // SCE_TOUCH_MAX_REPORT = 8
 enum {
-	SCE_TOUCH_MAX_REPORT	= 6	//!< FIXME 6 on front | 4 on back
+	SCE_TOUCH_MAX_REPORT	= 8	//!< FIXME 6 on front | 4 on back
 };
 
 /**


### PR DESCRIPTION
For Unity PSM, LTRIGGER and RTRIGGER are 0x400 and 0x800 respectively, so 0x500 and 0xA00 are compatible with both regular PSM and Unity PSM.

Also, SCE_TOUCH_MAX_REPORT needs to be 8, otherwise TouchData isn't large enough and memory is overwritten when sceTouchPeek is called...
