### PR TITLE
Fix for issue where sceTouchPeek/sceTouchRead overwrites memory

### DIFF
--- a/include/psp2/touch.h
+++ b/include/psp2/touch.h
@@ -20,7 +20,7 @@ extern "C" {
 
 // SCE_TOUCH_MAX_REPORT = 8
 enum {
-	SCE_TOUCH_MAX_REPORT	= 6	//!< FIXME 6 on front | 4 on back
+	SCE_TOUCH_MAX_REPORT	= 8	//!< FIXME 6 on front | 4 on back
 };
 
 /**


### PR DESCRIPTION
Fix for issue where sceTouchPeek/sceTouchRead overwrites memory because SceTouchData is not large enough due to SCE_TOUCH_MAX_REPORT.
